### PR TITLE
Mark this bundle as an SDK extension

### DIFF
--- a/org.freedesktop.Sdk.Extension.php74.metainfo.xml
+++ b/org.freedesktop.Sdk.Extension.php74.metainfo.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<component type="runtime">
+<component type="addon">
   <id>org.freedesktop.Sdk.Extension.php74</id>
+  <extends>org.freedesktop.Sdk</extends>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>PHP-3.0 AND BSD-3-Clause AND MIT</project_license>
-  <name>PHP 7.4 SDK extension</name>
-  <summary>PHP 7.4 SDK extension</summary>
+  <name>PHP 7.4</name>
+  <summary>PHP 7.4 extension for the flatpak Freedesktop SDK</summary>
   <url type="homepage">https://php.net</url>
   <update_contact>matthew@stobbs.ca</update_contact>
   <description>


### PR DESCRIPTION
This slightly improves UX for developers who use the flatpak SDK extensions in IDEs, by making the extension visible on the Freedesktop SDK page in frontends.